### PR TITLE
fix: update ChatResponse and StreamEvent  type

### DIFF
--- a/dify_client/models/base.py
+++ b/dify_client/models/base.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 class Mode(StrEnum):
     CHAT = "chat"
     COMPLETION = "completion"
-
+    ADAVANCED_CHAT = "advanced-chat"
 
 class ResponseMode(StrEnum):
     STREAMING = 'streaming'

--- a/dify_client/models/stream.py
+++ b/dify_client/models/stream.py
@@ -26,7 +26,8 @@ class StreamEvent(StrEnum):
     MESSAGE_REPLACE = "message_replace"
     ERROR = "error"
     PING = "ping"
-
+    TTS_MESSAGE_END = "tts_message_end"
+    
     @classmethod
     def new(cls, event: Union["StreamEvent", str]) -> "StreamEvent":
         if isinstance(event, cls):


### PR DESCRIPTION
更新DIFY接口对应的ChatResponse以及StreamEvent类型。
否则运行README demo 报两个错：

```
Traceback (most recent call last):
  File "/home/szu/code/dify-client-python/test_dify_client.py", line 24, in <module>
    chat_response = client.chat_messages(blocking_chat_req, timeout=60.)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/szu/code/dify-client-python/dify_client/_clientx.py", line 256, in chat_messages
    return self._chat_messages(req, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/szu/code/dify-client-python/dify_client/_clientx.py", line 268, in _chat_messages
    return models.ChatResponse(**response.json())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/szu/miniconda3/envs/llm-base/lib/python3.11/site-packages/pydantic/main.py", line 193, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatResponse
mode
  Input should be 'chat' or 'completion' [type=enum, input_value='advanced-chat', input_type=str]
    For further information visit https://errors.pydantic.dev/2.8/v/enum
```

```
Traceback (most recent call last):
  File "/home/szu/code/dify-client-python/test_dify_client.py", line 36, in <module>
    for chunk in client.chat_messages(streaming_chat_req, timeout=60.):
  File "/home/szu/code/dify-client-python/dify_client/_clientx.py", line 278, in _chat_messages_stream
    yield models.build_chat_stream_response(sse.json())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/szu/code/dify-client-python/dify_client/models/stream.py", line 165, in build_chat_stream_response
    event = StreamEvent.new(data.get(STREAM_EVENT_KEY))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/szu/code/dify-client-python/dify_client/models/stream.py", line 34, in new
    return utils.str_to_enum(cls, event)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/szu/code/dify-client-python/dify_client/utils/_common.py", line 7, in str_to_enum
    raise ValueError(f"Invalid enum value: {str_value}")
ValueError: Invalid enum value: tts_message_end
```
